### PR TITLE
fix for System.ArgumentException when referencing a static property in the template

### DIFF
--- a/Antlr4.StringTemplate/Misc/ObjectModelAdaptor.cs
+++ b/Antlr4.StringTemplate/Misc/ObjectModelAdaptor.cs
@@ -122,6 +122,13 @@ namespace Antlr4.StringTemplate.Misc
                         method = type.GetMethod("get_" + name, Type.EmptyTypes);
                 }
 
+                if (method == null)
+                {
+                    method = type.GetMethod(methodSuffix, Type.EmptyTypes);
+                    if (method == null && checkOriginalName)
+                        method = type.GetMethod(name, Type.EmptyTypes);
+                }
+
                 if (method != null)
                 {
                     accessor = BuildAccessor(method);
@@ -173,13 +180,20 @@ namespace Antlr4.StringTemplate.Misc
 
         private static System.Func<object, object> BuildAccessor(MethodInfo method)
         {
-            ParameterExpression obj = Expression.Parameter(typeof(object), "obj");
+
+            ParameterExpression obj = Expression.Parameter(typeof (object), "obj");
+            UnaryExpression unaryExpression = null;
+
+            if (!method.IsStatic)
+            {
+                unaryExpression = Expression.Convert(obj, method.DeclaringType);
+            }
+
             Expression<System.Func<object, object>> expr = Expression.Lambda<System.Func<object, object>>(
                 Expression.Convert(
                     Expression.Call(
-                        Expression.Convert(obj, method.DeclaringType),
-                        method),
-                    typeof(object)),
+                        unaryExpression, method),
+                    typeof (object)),
                 obj);
 
             return expr.Compile();

--- a/Antlr4.Test.StringTemplate/BaseTest.cs
+++ b/Antlr4.Test.StringTemplate/BaseTest.cs
@@ -172,6 +172,16 @@ namespace Antlr4.Test.StringTemplate
                     return name;
                 }
             }
+
+            public static string StaticMethod()
+            {
+                return "method_result";
+            }
+
+            public static string StaticProperty
+            {
+                get { return "property_result"; } 
+            }
         }
 
         public class HashableUser : User

--- a/Antlr4.Test.StringTemplate/TestCoreBasics.cs
+++ b/Antlr4.Test.StringTemplate/TestCoreBasics.cs
@@ -153,6 +153,7 @@ namespace Antlr4.Test.StringTemplate
             Assert.AreEqual(expected, result);
         }
 
+
         [TestMethod][TestCategory(TestCategories.ST4)]
         public void TestPropWithNoAttr()
         {
@@ -188,6 +189,7 @@ namespace Antlr4.Test.StringTemplate
             Assert.AreEqual(expected, result);
         }
 
+
         [TestMethod][TestCategory(TestCategories.ST4)]
         public void TestBooleanISProp()
         {
@@ -206,6 +208,30 @@ namespace Antlr4.Test.StringTemplate
             Template st = new Template(template);
             st.Add("t", new User(32, "Ter"));
             string expected = "true";
+            string result = st.Render();
+            Assert.AreEqual(expected, result);
+        }
+
+        [TestMethod]
+        [TestCategory(TestCategories.ST4)]
+        public void TestStaticMethod()
+        {
+            string template = "<t.StaticMethod>"; // call StaticMethod
+            Template st = new Template(template);
+            st.Add("t", new User(32, "Ter"));
+            string expected = "method_result";
+            string result = st.Render();
+            Assert.AreEqual(expected, result);
+        }
+
+        [TestMethod]
+        [TestCategory(TestCategories.ST4)]
+        public void TestStatiProperty()
+        {
+            string template = "<t.StaticProperty>"; // call StaticProperty
+            Template st = new Template(template);
+            st.Add("t", new User(32, "Ter"));
+            string expected = "property_result";
             string result = st.Render();
             Assert.AreEqual(expected, result);
         }


### PR DESCRIPTION
Hi,

Visual Studio gemerates resource helpers with static getters, when using such a helper  the following exception is thrown:
context [anonymous] 1:1 internal error: System.ArgumentException: Static method requires null instance, non-static method requires non-null instance.
Parameter name: instance

I'm sending a simple fix

Greetings,
