### PR TITLE
Fix build warnings

### DIFF
--- a/Antlr3.Runtime.Visualizer/Antlr3.Runtime.Visualizer.csproj
+++ b/Antlr3.Runtime.Visualizer/Antlr3.Runtime.Visualizer.csproj
@@ -33,6 +33,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup>
+    <CodeAnalysisRuleSet>..\Antlr3.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup>
     <SignAssembly>true</SignAssembly>
   </PropertyGroup>
   <PropertyGroup>

--- a/Antlr3.StringTemplate/Antlr3.StringTemplate.csproj
+++ b/Antlr3.StringTemplate/Antlr3.StringTemplate.csproj
@@ -35,6 +35,9 @@
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Release\Antlr3.StringTemplate.xml</DocumentationFile>
   </PropertyGroup>
+  <PropertyGroup>
+    <CodeAnalysisRuleSet>..\Antlr3.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core">

--- a/Antlr3.StringTemplate/Language/StringTemplateToken.cs
+++ b/Antlr3.StringTemplate/Language/StringTemplateToken.cs
@@ -39,7 +39,7 @@ namespace Antlr3.ST.Language
     {
         /** <summary>
          *  Track any args for anonymous templates like
-         *  &lt;tokens,rules:{t,r | <t> then <r>}>
+         *  &lt;tokens,rules:{t,r | &lt;t&gt; then &lt;r&gt;}>
          *  The lexer in action.g returns a single token ANONYMOUS_TEMPLATE
          *  and so I need to have it parse args in the lexer and make them
          *  available for when I build the anonymous template.

--- a/Antlr3.Test/Antlr3.Test.csproj
+++ b/Antlr3.Test/Antlr3.Test.csproj
@@ -23,6 +23,9 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+  <PropertyGroup>
+    <CodeAnalysisRuleSet>..\Antlr3.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="System" />

--- a/Antlr3.ruleset
+++ b/Antlr3.ruleset
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<RuleSet Name="Code Analysis Rules for ANTLR 3" Description=" " ToolsVersion="14.0">
+  <Rules AnalyzerId="Microsoft.CodeAnalysis.CSharp" RuleNamespace="Microsoft.CodeAnalysis.CSharp">
+    <Rule Id="CS1573" Action="None" />
+    <Rule Id="CS1591" Action="None" />
+  </Rules>
+</RuleSet>

--- a/Antlr3.sln
+++ b/Antlr3.sln
@@ -7,6 +7,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Targets", "Targets", "{3A92
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{C0B451C4-EAFC-4942-B18E-49EC73DABABD}"
 	ProjectSection(SolutionItems) = preProject
+		Antlr3.ruleset = Antlr3.ruleset
 		Antlr3.vsmdi = Antlr3.vsmdi
 		AntlrTestConfig.testrunconfig = AntlrTestConfig.testrunconfig
 		PublishingProcess.txt = PublishingProcess.txt

--- a/Antlr3/Analysis/DFA.cs
+++ b/Antlr3/Analysis/DFA.cs
@@ -598,7 +598,7 @@ namespace Antlr3.Analysis
          *  gives
          * 
          * .s0-X->.s1
-         * .s0-Y&&{synpred1_t}?->:s2=>1
+         * .s0-Y&amp;&amp;{synpred1_t}?->:s2=>1
          * .s1-{synpred1_t}?->:s2=>1
          * .s1-{true}?->:s3=>2
          */

--- a/Antlr3/Analysis/DFAState.cs
+++ b/Antlr3/Analysis/DFAState.cs
@@ -402,7 +402,7 @@ namespace Antlr3.Analysis
         }
 
         /** Add an NFA configuration to this DFA node.  Add uniquely
-         *  an NFA state/alt/syntactic&semantic context (chain of invoking state(s)
+         *  an NFA state/alt/syntactic&amp;semantic context (chain of invoking state(s)
          *  and semantic predicate contexts).
          *
          *  I don't see how there could be two configurations with same
@@ -498,7 +498,7 @@ namespace Antlr3.Analysis
          *
          *  The idea for adding a new set, t, is to look for overlap with the
          *  elements of existing list s.  Upon overlap, replace
-         *  existing set s[i] with two new disjoint sets, s[i]-t and s[i]&t.
+         *  existing set s[i] with two new disjoint sets, s[i]-t and s[i]&amp;t.
          *  (if s[i]-t is nil, don't add).  The remainder is t-s[i], which is
          *  what you want to add to the set minus what was already there.  The
          *  remainder must then be compared against the i+1..n elements in s

--- a/Antlr3/Analysis/DecisionProbe.cs
+++ b/Antlr3/Analysis/DecisionProbe.cs
@@ -161,7 +161,7 @@ namespace Antlr3.Analysis
          *  an input sequence.  Tracks the input position
          *  we were at the last time at this node.  If same input position, then
          *  we'd have reached same state without consuming input...probably an
-         *  infinite loop.  Stop.  Set<String>.  The strings look like
+         *  infinite loop.  Stop.  Set of strings.  The strings look like
          *  stateNumber_labelIndex.
          */
         private ICollection<string> _statesVisitedAtInputDepth;
@@ -375,7 +375,7 @@ namespace Antlr3.Analysis
             _stateToRecursionOverflowConfigurationsMap.Remove( d.StateNumber );
         }
 
-        /** Return a IList<Label> indicating an input sequence that can be matched
+        /** Return a IList&lt;Label&gt; indicating an input sequence that can be matched
          *  from the start state of the DFA to the targetState (which is known
          *  to have a problem).
          */
@@ -900,7 +900,7 @@ namespace Antlr3.Analysis
         /** Given a start state and a final state, find a list of edge labels
          *  between the two ignoring epsilon.  Limit your scan to a set of states
          *  passed in.  This is used to show a sample input sequence that is
-         *  nondeterministic with respect to this decision.  Return IList<Label> as
+         *  nondeterministic with respect to this decision.  Return IList&lt;Label&gt; as
          *  a parameter.  The incoming states set must be all states that lead
          *  from startState to targetState and no others so this algorithm doesn't
          *  take a path that eventually leads to a state other than targetState.

--- a/Antlr3/Analysis/Label.cs
+++ b/Antlr3/Analysis/Label.cs
@@ -121,7 +121,9 @@ namespace Antlr3.Analysis
         /** tokens and char range overlap; tokens are MIN_TOKEN_TYPE..n */
         public const int MIN_TOKEN_TYPE = TokenTypes.Min;
 
-        /** The wildcard '.' char atom implies all valid characters==UNICODE */
+        ///// <summary>
+        ///// The wildcard '.' char atom implies all valid characters==UNICODE
+        ///// </summary>
         //public static readonly IIntSet ALLCHAR = IntervalSet.of( MIN_CHAR_VALUE, MAX_CHAR_VALUE );
 
         /** The token type or character value; or, signifies special label. */

--- a/Antlr3/Analysis/NFAConfiguration.cs
+++ b/Antlr3/Analysis/NFAConfiguration.cs
@@ -81,9 +81,10 @@ namespace Antlr3.Analysis
          */
         private bool _resolveWithPredicate;
 
-        /** Lots of NFA states have only epsilon edges (1 or 2).  We can
-         *  safely consider only n>0 during closure.
-         */
+        ///// <summary>
+        ///// Lots of NFA states have only epsilon edges (1 or 2).  We can
+        ///// safely consider only n>0 during closure.
+        ///// </summary>
         //int _numberEpsilonTransitionsEmanatingFromState;
 
         /** Indicates that the NFA state associated with this configuration

--- a/Antlr3/Analysis/NFAConfiguration.cs
+++ b/Antlr3/Analysis/NFAConfiguration.cs
@@ -55,7 +55,7 @@ namespace Antlr3.Analysis
         /** The set of semantic predicates associated with this NFA
          *  configuration.  The predicates were found on the way to
          *  the associated NFA state in this syntactic context.
-         *  Set<AST>: track nodes in grammar containing the predicate
+         *  Set of AST: track nodes in grammar containing the predicate
          *  for error messages and such (nice to know where the predicate
          *  came from in case of duplicates etc...).  By using a set,
          *  the equals() method will correctly show {pred1,pred2} as equals()

--- a/Antlr3/Analysis/NFAContext.cs
+++ b/Antlr3/Analysis/NFAContext.cs
@@ -211,7 +211,7 @@ namespace Antlr3.Analysis
          *  This is used in relation to checking conflicts associated with a
          *  single NFA state's configurations within a single DFA state.
          *  If there are configurations s and t within a DFA state such that
-         *  s.state=t.state && s.alt != t.alt && s.ctx conflicts t.ctx then
+         *  s.state=t.state &amp;&amp; s.alt != t.alt &amp;&amp; s.ctx conflicts t.ctx then
          *  the DFA state predicts more than a single alt--it's nondeterministic.
          *  Two contexts conflict if they are the same or if one is a suffix
          *  of the other.

--- a/Antlr3/Analysis/NFAtoDFAConverter.cs
+++ b/Antlr3/Analysis/NFAtoDFAConverter.cs
@@ -384,14 +384,14 @@ namespace Antlr3.Analysis
          *
          *  The normal decision to predict alts 1, 2, 3 is:
          *
-         *  if ( (input.LA(1)>='1' && input.LA(1)&lt;='9') ) {
+         *  if ( (input.LA(1)>='1' &amp;&amp; input.LA(1)&lt;='9') ) {
          *       alt7=1;
          *  }
          *  else if ( input.LA(1)=='0' ) {
          *      if ( input.LA(2)=='X'||input.LA(2)=='x' ) {
          *          alt7=2;
          *      }
-         *      else if ( (input.LA(2)>='0' && input.LA(2)&lt;='7') ) {
+         *      else if ( (input.LA(2)>='0' &amp;&amp; input.LA(2)&lt;='7') ) {
          *           alt7=3;
          *      }
          *      else if ( input.LA(2)=='L'||input.LA(2)=='l' ) {
@@ -409,7 +409,7 @@ namespace Antlr3.Analysis
          *
          *  A better decision is as follows:
          *
-         *  if ( (input.LA(1)>='1' && input.LA(1)&lt;='9') ) {
+         *  if ( (input.LA(1)>='1' &amp;&amp; input.LA(1)&lt;='9') ) {
          *      alt7=1;
          *  }
          *  else if ( input.LA(1)=='0' ) {
@@ -1236,7 +1236,7 @@ namespace Antlr3.Analysis
          *  it uniquely predicts one alt. :)  Problem
          *  states will look like this during conversion:
          *
-         *  DFA 1:{9|1, 19|2, 14|3, 20|2, 23|2, 24|2, ...}-<EOT>->5:{41|3, 42|2}
+         *  DFA 1:{9|1, 19|2, 14|3, 20|2, 23|2, 24|2, ...}-&lt;EOT&gt;->5:{41|3, 42|2}
          *
          *  Worse, when you have two identical literal rules, you will see 3 alts
          *  in the EOT state (one for ID and one each for the identical rules).

--- a/Antlr3/Analysis/SemanticContext.cs
+++ b/Antlr3/Analysis/SemanticContext.cs
@@ -48,7 +48,7 @@ namespace Antlr3.Analysis
 
     /** A binary tree structure used to record the semantic context in which
      *  an NFA configuration is valid.  It's either a single predicate or
-     *  a tree representing an operation tree such as: p1&&p2 or p1||p2.
+     *  a tree representing an operation tree such as: p1&amp;&amp;p2 or p1||p2.
      *
      *  For NFA o-p1->o-p2->o, create tree AND(p1,p2).
      *  For NFA (1)-p1->(2)
@@ -76,8 +76,8 @@ namespace Antlr3.Analysis
         public static readonly SemanticContext EmptySemanticContext = new Predicate(Predicate.InvalidPredValue);
 
         /** Given a semantic context expression tree, return a tree with all
-         *  nongated predicates set to true and then reduced.  So p&&(q||r) would
-         *  return p&&r if q is nongated but p and r are gated.
+         *  nongated predicates set to true and then reduced.  So p&amp;&amp;(q||r) would
+         *  return p&amp;&amp;r if q is nongated but p and r are gated.
          */
         public abstract SemanticContext GatedPredicateContext
         {

--- a/Antlr3/Antlr3.csproj
+++ b/Antlr3/Antlr3.csproj
@@ -35,6 +35,9 @@
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>..\bin\Release\Antlr3.xml</DocumentationFile>
   </PropertyGroup>
+  <PropertyGroup>
+    <CodeAnalysisRuleSet>..\Antlr3.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core">

--- a/Antlr3/Codegen/CodeGenerator.cs
+++ b/Antlr3/Codegen/CodeGenerator.cs
@@ -1179,7 +1179,7 @@ namespace Antlr3.Codegen
         }
 
         /** For intervals such as [3..3, 30..35], generate an expression that
-         *  tests the lookahead similar to LA(1)==3 || (LA(1)>=30&&LA(1)<=35)
+         *  tests the lookahead similar to LA(1)==3 || (LA(1)>=30&amp;&amp;LA(1)&lt;=35)
          */
         public virtual StringTemplate GenSetExpr( TemplateGroup templates,
                                          IIntSet set,
@@ -1823,7 +1823,7 @@ namespace Antlr3.Codegen
         /** Create a label to track a token / rule reference's result.
          *  Technically, this is a place where I break model-view separation
          *  as I am creating a variable name that could be invalid in a
-         *  target language, however, label ::= <ID><INT> is probably ok in
+         *  target language, however, label ::= &lt;ID&gt;&lt;INT&gt; is probably ok in
          *  all languages we care about.
          */
         public virtual string CreateUniqueLabel( string name )

--- a/Antlr3/Grammars/AssignTokenTypesWalker.g3
+++ b/Antlr3/Grammars/AssignTokenTypesWalker.g3
@@ -68,15 +68,15 @@
  *  1. Finds a list of all literals and token names.
  *  2. Finds a list of all token name rule definitions;
  *     no token rules implies pure parser.
- *  3. Finds a list of all simple token rule defs of form "<NAME> : <literal>;"
+ *  3. Finds a list of all simple token rule defs of form "&lt;NAME&gt; : &lt;literal&gt;;"
  *     and aliases them.
  *  4. Walks token names table and assign types to any unassigned
  *  5. Walks aliases and assign types to referenced literals
  *  6. Walks literals, assigning types if untyped
  *  4. Informs the Grammar object of the type definitions such as:
- *     g.defineToken(<charliteral>, ttype);
- *     g.defineToken(<stringliteral>, ttype);
- *     g.defineToken(<tokenID>, ttype);
+ *     g.defineToken(&lt;charliteral&gt;, ttype);
+ *     g.defineToken(&lt;stringliteral&gt;, ttype);
+ *     g.defineToken(&lt;tokenID&gt;, ttype);
  *     where some of the ttype values will be the same for aliases tokens.
  */
 tree grammar AssignTokenTypesWalker;

--- a/Antlr3/Misc/IntervalSet.cs
+++ b/Antlr3/Misc/IntervalSet.cs
@@ -143,7 +143,7 @@ namespace Antlr3.Misc
         }
 
         /** Add interval; i.e., add all integers from a to b to set.
-         *  If b<a, do nothing.
+         *  If b&lt;a, do nothing.
          *  Keep list in sorted order (by left range value).
          *  If overlap, combine ranges.  For example,
          *  If this is {1..5, 10..20}, adding 6..7 yields
@@ -356,7 +356,7 @@ namespace Antlr3.Misc
             return compl;
         }
 
-        /** Compute this-other via this&~other.
+        /** Compute this-other via this&amp;~other.
          *  Return a new set containing all elements in this but not in other.
          *  other is assumed to be a subset of this;
          *  anything that is in other but not in this will be ignored.

--- a/Antlr3/Misc/OrderedHashSet.cs
+++ b/Antlr3/Misc/OrderedHashSet.cs
@@ -56,7 +56,7 @@ namespace Antlr3.Misc
                 return _elements[i];
             }
 
-            /** Replace an existing value with a new value; updates the element
+            /* Replace an existing value with a new value; updates the element
              *  list and the hash table, but not the key as that has not changed.
              */
             set

--- a/Antlr3/Tool/ErrorManager.cs
+++ b/Antlr3/Tool/ErrorManager.cs
@@ -203,7 +203,7 @@ namespace Antlr3.Tool
             };
 
         /** Only one error can be emitted for any entry in this table.
-         *  Map<String,Set> where the key is a method name like danglingState.
+         *  Map from string to a set where the key is a method name like danglingState.
          *  The set is whatever that method accepts or derives like a DFA.
          */
         public static readonly IDictionary<string, ICollection<object>> emitSingleError =
@@ -527,7 +527,7 @@ namespace Antlr3.Tool
             String fileName = "org/antlr/tool/templates/messages/"+language+".stg";
             ClassLoader cl = Thread.currentThread().getContextClassLoader();
             InputStream is = cl.getResourceAsStream(fileName);
-            if ( is==null && language.equals(Locale.US.getLanguage()) ) {
+            if ( is==null &amp;&amp; language.equals(Locale.US.getLanguage()) ) {
                 return null;
             }
             else if ( is==null ) {
@@ -535,7 +535,7 @@ namespace Antlr3.Tool
             }
 
             boolean messagesOK = verifyMessages();
-            if ( !messagesOK && language.equals(Locale.US.getLanguage()) ) {
+            if ( !messagesOK &amp;&amp; language.equals(Locale.US.getLanguage()) ) {
                 return null;
             }
             else if ( !messagesOK ) {

--- a/Antlr3/Tool/Grammar.cs
+++ b/Antlr3/Tool/Grammar.cs
@@ -448,7 +448,7 @@ namespace Antlr3.Tool
 
         /** An AST that records entire input grammar with all rules.  A simple
          *  grammar with one rule, "grammar t; a : A | B ;", looks like:
-         * ( grammar t ( rule a ( BLOCK ( ALT A ) ( ALT B ) ) <end-of-rule> ) )
+         * ( grammar t ( rule a ( BLOCK ( ALT A ) ( ALT B ) ) &lt;end-of-rule&gt; ) )
          */
         protected GrammarAST grammarTree = null;
 
@@ -2973,7 +2973,7 @@ namespace Antlr3.Tool
             delegateGrammar.composite = this.composite;
         }
 
-        /** Load a vocab file <vocabName>.tokens and return max token type found. */
+        /** Load a vocab file &lt;vocabName&gt;.tokens and return max token type found. */
         public virtual int ImportTokenVocabulary( GrammarAST tokenVocabOptionAST,
                                          string vocabName )
         {
@@ -3733,7 +3733,7 @@ namespace Antlr3.Tool
         }
 
         /** given a token type and the text of the literal, come up with a
-         *  decent token type label.  For now it's just T<type>.  Actually,
+         *  decent token type label.  For now it's just T&lt;type&gt;.  Actually,
          *  if there is an aliased name from tokens like PLUS='+', use it.
          */
         public virtual string ComputeTokenNameFromLiteral( int tokenType, string literal )

--- a/Antlr3/Tool/GrammarSanity.cs
+++ b/Antlr3/Tool/GrammarSanity.cs
@@ -169,7 +169,7 @@ namespace Antlr3.Tool
         /** enclosingRuleName calls targetRuleName, find the cycle containing
          *  the target and add the caller.  Find the cycle containing the caller
          *  and add the target.  If no cycles contain either, then create a new
-         *  cycle.  listOfRecursiveCycles is List<Set<String>> that holds a list
+         *  cycle.  listOfRecursiveCycles is List&lt;Set&lt;String&gt;&gt; that holds a list
          *  of cycles (sets of rule names).
          */
         protected virtual void AddRulesToCycle( Rule targetRule,
@@ -285,7 +285,7 @@ namespace Antlr3.Tool
          *  use -> on alts that are simple nodes or trees or single rule refs
          *  that match either nodes or trees.  The altAST is the ALT node
          *  for an ALT.  Verify that its first child is simple.  Must be either
-         *  ( ALT ^( A B ) <end-of-alt> ) or ( ALT A <end-of-alt> ) or
+         *  ( ALT ^( A B ) &lt;end-of-alt&gt; ) or ( ALT A &lt;end-of-alt&gt; ) or
          *  other element.
          *
          *  Ignore predicates in front and labels.

--- a/Antlr4.StringTemplate.Visualizer/Antlr4.StringTemplate.Visualizer.csproj
+++ b/Antlr4.StringTemplate.Visualizer/Antlr4.StringTemplate.Visualizer.csproj
@@ -36,6 +36,9 @@
     <DocumentationFile>bin\Release\Antlr4.StringTemplate.Visualizer.xml</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup>
+    <CodeAnalysisRuleSet>..\Antlr3.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup>
     <SignAssembly>true</SignAssembly>
   </PropertyGroup>
   <PropertyGroup>

--- a/Antlr4.StringTemplate/Antlr4.StringTemplate.csproj
+++ b/Antlr4.StringTemplate/Antlr4.StringTemplate.csproj
@@ -33,6 +33,9 @@
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Release\Antlr4.StringTemplate.xml</DocumentationFile>
   </PropertyGroup>
+  <PropertyGroup>
+    <CodeAnalysisRuleSet>..\Antlr3.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Antlr4.StringTemplate/Compiler/CodeGenerator.g3
+++ b/Antlr4.StringTemplate/Compiler/CodeGenerator.g3
@@ -145,13 +145,13 @@ subtemplate returns [string name, int nargs]
 
 ifstat[CommonTree indent]
 @init {
-	///** Tracks address of branch operand (in code block).  It's how
-	//	*  we backpatch forward references when generating code for IFs.
-	//	*/
+	/* Tracks address of branch operand (in code block).  It's how
+	 * we backpatch forward references when generating code for IFs.
+	 */
 	int prevBranchOperand = -1;
-	///** Branch instruction operands that are forward refs to end of IF.
-	//	*  We need to update them once we see the endif.
-	//	*/
+	/* Branch instruction operands that are forward refs to end of IF.
+	 * We need to update them once we see the endif.
+	 */
 	List<int> endRefs = new List<int>();
 	if ($indent != null) Indent($indent);
 }

--- a/Antlr4.StringTemplate/IModelAdaptor.cs
+++ b/Antlr4.StringTemplate/IModelAdaptor.cs
@@ -39,7 +39,7 @@ namespace Antlr4.StringTemplate
      *  an object of type M with property method foo() (not getFoo()), we
      *  register a model adaptor object, adap, that converts foo lookup to foo().
      *
-     *  Given <a.foo>, we look up foo via the adaptor if "a instanceof(M)".
+     *  Given &lt;a.foo&gt;, we look up foo via the adaptor if "a instanceof(M)".
      *
      *  See unit tests.
      */

--- a/Antlr4.StringTemplate/Misc/Utility.cs
+++ b/Antlr4.StringTemplate/Misc/Utility.cs
@@ -98,7 +98,7 @@ namespace Antlr4.StringTemplate.Misc
         }
 
         /** Replace >\> with >> in s. Replace \>> unless prefix of \>>> with >>.
-         *  Do NOT replace if it's <\\>
+         *  Do NOT replace if it's &lt;\\&gt;
          */
         public static string ReplaceEscapedRightAngle(string s)
         {

--- a/Antlr4.StringTemplate/Template.cs
+++ b/Antlr4.StringTemplate/Template.cs
@@ -60,7 +60,7 @@ namespace Antlr4.StringTemplate
      */
     public class Template
     {
-        /** <@r()>, <@r>...<@end>, and @t.r() ::= "..." defined manually by coder */
+        /** &lt;@r()&gt;, &lt;@r&gt;...&lt;@end&gt;, and @t.r() ::= "..." defined manually by coder */
         public enum RegionType
         {
             /// <summary>

--- a/Antlr4.Test.StringTemplate/Antlr4.Test.StringTemplate.csproj
+++ b/Antlr4.Test.StringTemplate/Antlr4.Test.StringTemplate.csproj
@@ -32,6 +32,9 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+  <PropertyGroup>
+    <CodeAnalysisRuleSet>..\Antlr3.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="System" />

--- a/AntlrBuildTask/AntlrBuildTask.csproj
+++ b/AntlrBuildTask/AntlrBuildTask.csproj
@@ -34,6 +34,9 @@
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>..\bin\Release\AntlrBuildTask.xml</DocumentationFile>
   </PropertyGroup>
+  <PropertyGroup>
+    <CodeAnalysisRuleSet>..\Antlr3.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.Build.Engine" />
     <Reference Include="Microsoft.Build.Framework" />

--- a/Runtime/Antlr3.Runtime.Debug/Antlr3.Runtime.Debug.csproj
+++ b/Runtime/Antlr3.Runtime.Debug/Antlr3.Runtime.Debug.csproj
@@ -34,6 +34,9 @@
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Release\Antlr3.Runtime.Debug.xml</DocumentationFile>
   </PropertyGroup>
+  <PropertyGroup>
+    <CodeAnalysisRuleSet>..\..\Antlr3.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
   </ItemGroup>

--- a/Runtime/Antlr3.Runtime.Debug/Profiler.cs
+++ b/Runtime/Antlr3.Runtime.Debug/Profiler.cs
@@ -45,7 +45,7 @@ namespace Antlr.Runtime.Debug
     using StringBuilder = System.Text.StringBuilder;
 
     /** <summary>Using the debug event interface, track what is happening in the parser
-     *  and record statistics about the runtime.
+     *  and record statistics about the runtime.</summary>
      */
     public class Profiler : BlankDebugEventListener
     {

--- a/Runtime/Antlr3.Runtime.JavaExtensions/Antlr3.Runtime.JavaExtensions.csproj
+++ b/Runtime/Antlr3.Runtime.JavaExtensions/Antlr3.Runtime.JavaExtensions.csproj
@@ -32,6 +32,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup>
+    <CodeAnalysisRuleSet>..\..\Antlr3.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup>
     <SignAssembly>true</SignAssembly>
   </PropertyGroup>
   <PropertyGroup>

--- a/Runtime/Antlr3.Runtime.Test/Antlr3.Runtime.Test.csproj
+++ b/Runtime/Antlr3.Runtime.Test/Antlr3.Runtime.Test.csproj
@@ -31,6 +31,9 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+  <PropertyGroup>
+    <CodeAnalysisRuleSet>..\..\Antlr3.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="System" />

--- a/Runtime/Antlr3.Runtime/Antlr3.Runtime.net20.csproj
+++ b/Runtime/Antlr3.Runtime/Antlr3.Runtime.net20.csproj
@@ -35,6 +35,9 @@
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\net20\Release\Antlr3.Runtime.xml</DocumentationFile>
   </PropertyGroup>
+  <PropertyGroup>
+    <CodeAnalysisRuleSet>..\..\Antlr3.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
   </ItemGroup>

--- a/Runtime/Antlr3.Runtime/Antlr3.Runtime.net40-client.csproj
+++ b/Runtime/Antlr3.Runtime/Antlr3.Runtime.net40-client.csproj
@@ -36,6 +36,9 @@
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\net40-client\Release\Antlr3.Runtime.xml</DocumentationFile>
   </PropertyGroup>
+  <PropertyGroup>
+    <CodeAnalysisRuleSet>..\..\Antlr3.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
   </ItemGroup>

--- a/Runtime/Antlr3.Runtime/Antlr3.Runtime.portable-net40.csproj
+++ b/Runtime/Antlr3.Runtime/Antlr3.Runtime.portable-net40.csproj
@@ -37,6 +37,9 @@
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\portable-net40\Release\Antlr3.Runtime.xml</DocumentationFile>
   </PropertyGroup>
+  <PropertyGroup>
+    <CodeAnalysisRuleSet>..\..\Antlr3.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Include="ANTLRFileStream.cs" />
     <Compile Include="ANTLRInputStream.cs" />

--- a/Runtime/Antlr3.Runtime/Antlr3.Runtime.portable-net45.csproj
+++ b/Runtime/Antlr3.Runtime/Antlr3.Runtime.portable-net45.csproj
@@ -37,6 +37,9 @@
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\portable-net45\Release\Antlr3.Runtime.xml</DocumentationFile>
   </PropertyGroup>
+  <PropertyGroup>
+    <CodeAnalysisRuleSet>..\..\Antlr3.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Include="ANTLRFileStream.cs" />
     <Compile Include="ANTLRInputStream.cs" />

--- a/Runtime/Antlr3.Runtime/BaseRecognizer.cs
+++ b/Runtime/Antlr3.Runtime/BaseRecognizer.cs
@@ -383,7 +383,7 @@ namespace Antlr.Runtime
          *  an error and next valid token match
          *  </summary>
          *
-         *  <seealso cref="reportError()"/>
+         *  <seealso cref="ReportError(RecognitionException)"/>
          */
         public virtual int NumberOfSyntaxErrors
         {

--- a/Runtime/Antlr3.Runtime/BaseRecognizer.cs
+++ b/Runtime/Antlr3.Runtime/BaseRecognizer.cs
@@ -835,7 +835,7 @@ namespace Antlr.Runtime
 
 #if !PORTABLE
         /** <summary>
-         *  Return List<String> of the rules in your parser instance
+         *  Return <see cref="IList{T}"/> of the rules in your parser instance
          *  leading up to a call to this method.  You could override if
          *  you want more details such as the file/line info of where
          *  in the parser java code a rule is invoked.
@@ -933,7 +933,7 @@ namespace Antlr.Runtime
 
         /** <summary>
          *  A convenience method for use most often with template rewrites.
-         *  Convert a List<Token> to List<String>
+         *  Convert a list of <see cref="IToken"/> to a list of <see cref="string"/>.
          *  </summary>
          */
         public virtual List<string> ToStrings( ICollection<IToken> tokens )

--- a/Runtime/Antlr3.Runtime/BitSet.cs
+++ b/Runtime/Antlr3.Runtime/BitSet.cs
@@ -55,7 +55,7 @@ namespace Antlr.Runtime
         /** <summary>
          *  We will often need to do a mod operator (i mod nbits).  Its
          *  turns out that, for powers of two, this mod operation is
-         *  same as (i & (nbits-1)).  Since mod is slow, we use a
+         *  same as (i &amp; (nbits-1)).  Since mod is slow, we use a
          *  precomputed mod mask to do the mod instead.
          *  </summary>
          */

--- a/Runtime/Antlr3.Runtime/BufferedTokenStream.cs
+++ b/Runtime/Antlr3.Runtime/BufferedTokenStream.cs
@@ -41,8 +41,8 @@ namespace Antlr.Runtime
      *  lexer. Useful when the parser or lexer has to set context/mode info before
      *  proper lexing of future tokens. The ST template parser needs this,
      *  for example, because it has to constantly flip back and forth between
-     *  inside/output templates. E.g., <names:{hi, <it>}> has to parse names
-     *  as part of an expression but "hi, <it>" as a nested template.
+     *  inside/output templates. E.g., <c>&lt;names:{hi, &lt;it&gt;}&gt;</c> has to parse names
+     *  as part of an expression but "hi, &lt;it&gt;" as a nested template.
      *
      *  You can't use this stream if you pass whitespace or other off-channel
      *  tokens to the parser. The stream can't ignore off-channel tokens.

--- a/Runtime/Antlr3.Runtime/CommonToken.cs
+++ b/Runtime/Antlr3.Runtime/CommonToken.cs
@@ -122,7 +122,7 @@ namespace Antlr.Runtime
 
             set
             {
-                /** Override the text for this token.  getText() will return this text
+                /* Override the text for this token.  getText() will return this text
                  *  rather than pulling from the buffer.  Note that this does not mean
                  *  that start/stop indexes are not valid.  It means that that input
                  *  was converted to a new string in the token object.

--- a/Runtime/Antlr3.Runtime/Debug/IDebugEventListener.cs
+++ b/Runtime/Antlr3.Runtime/Debug/IDebugEventListener.cs
@@ -32,6 +32,7 @@
 
 namespace Antlr.Runtime.Debug
 {
+    using ITreeAdaptor = Antlr.Runtime.Tree.ITreeAdaptor;
 
     /** <summary>All debugging events that a recognizer can trigger.</summary>
      *
@@ -358,7 +359,7 @@ namespace Antlr.Runtime.Debug
          *  RemoteDebugEventSocketListener then only IDs are set.
          *  </remarks>
          *
-         *  <seealso cref="Antlr.Runtime.Tree.TreeAdaptor.becomeRoot()"/>
+         *  <seealso cref="ITreeAdaptor.BecomeRoot(object, object)"/>
          */
         void BecomeRoot( object newRoot, object oldRoot );
 
@@ -369,7 +370,7 @@ namespace Antlr.Runtime.Debug
          *  RemoteDebugEventSocketListener then only IDs are set.
          *  </remarks>
          *
-         *  <seealso cref="Antlr.Runtime.Tree.TreeAdaptor.addChild()"/>
+         *  <seealso cref="ITreeAdaptor.AddChild(object, object)"/>
          */
         void AddChild( object root, object child );
 

--- a/Runtime/Antlr3.Runtime/Debug/IDebugEventListener.cs
+++ b/Runtime/Antlr3.Runtime/Debug/IDebugEventListener.cs
@@ -205,7 +205,7 @@ namespace Antlr.Runtime.Debug
          *		enterAlt1
          *		location 7 5
          *		LT(1)
-         *		consumeToken [c/<4>,1:0]
+         *		consumeToken [c/&lt;4&gt;,1:0]
          *		location 7 7
          *		enterSubRule 2
          *		enter decision 2
@@ -216,7 +216,7 @@ namespace Antlr.Runtime.Debug
          *		exitSubRule 2
          *		beginResync
          *		LT(1)
-         *		consumeToken [c/<4>,1:1]
+         *		consumeToken [c/&lt;4&gt;,1:1]
          *		LT(1)
          *		endResync
          *		LT(-1)

--- a/Runtime/Antlr3.Runtime/ITokenSource.cs
+++ b/Runtime/Antlr3.Runtime/ITokenSource.cs
@@ -48,7 +48,7 @@ namespace Antlr.Runtime
      *  lexing then you should not throw an exception to the parser--it has already
      *  requested a token.  Keep lexing until you get a valid one.  Just report
      *  errors and keep going, looking for a valid token.
-     *  </summary>
+     *  </remarks>
      */
     public interface ITokenSource
     {

--- a/Runtime/Antlr3.Runtime/LegacyCommonTokenStream.cs
+++ b/Runtime/Antlr3.Runtime/LegacyCommonTokenStream.cs
@@ -59,10 +59,10 @@ namespace Antlr.Runtime
          */
         protected List<IToken> tokens;
 
-        /** <summary>Map<tokentype, channel> to override some Tokens' channel numbers</summary> */
+        /** <summary>Map from token type to channel to override some Tokens' channel numbers</summary> */
         protected IDictionary<int, int> channelOverrideMap;
 
-        /** <summary>Set<tokentype>; discard any tokens with this type</summary> */
+        /** <summary>Set of token types; discard any tokens with this type</summary> */
         protected List<int> discardSet;
 
         /** <summary>Skip tokens on any channel but this one; this is how we skip whitespace...</summary> */

--- a/Runtime/Antlr3.Runtime/Lexer.cs
+++ b/Runtime/Antlr3.Runtime/Lexer.cs
@@ -62,9 +62,14 @@ namespace Antlr.Runtime
         }
 
         #region Properties
+        /// <summary>
+        /// Gets or sets the text matched so far for the current token or any text override.
+        /// </summary>
+        /// <remarks>
+        /// <para>Setting this value replaces any previously set value, and overrides the original text.</para>
+        /// </remarks>
         public string Text
         {
-            /** <summary>Return the text matched so far for the current token or any text override.</summary> */
             get
             {
                 if ( state.text != null )
@@ -73,7 +78,6 @@ namespace Antlr.Runtime
                 }
                 return input.Substring( state.tokenStartCharIndex, CharIndex - state.tokenStartCharIndex );
             }
-            /** <summary>Set the complete text of this token; it wipes any previous changes to the text.</summary> */
             set
             {
                 state.text = value;
@@ -203,7 +207,7 @@ namespace Antlr.Runtime
             {
                 return input;
             }
-            /** <summary>Set the char stream and reset the lexer</summary> */
+            /* Set the char stream and reset the lexer */
             set
             {
                 input = null;
@@ -327,15 +331,15 @@ namespace Antlr.Runtime
 
         public override void ReportError( RecognitionException e )
         {
-            /** TODO: not thought about recovery in lexer yet.
+            /* TODO: not thought about recovery in lexer yet.
              *
-            // if we've already reported an error and have not matched a token
-            // yet successfully, don't report any errors.
-            if ( errorRecovery ) {
-                //System.err.print("[SPURIOUS] ");
-                return;
-            }
-            errorRecovery = true;
+             * // if we've already reported an error and have not matched a token
+             * // yet successfully, don't report any errors.
+             * if ( errorRecovery ) {
+             *     //System.err.print("[SPURIOUS] ");
+             *     return;
+             * }
+             * errorRecovery = true;
              */
 
             DisplayRecognitionError( this.TokenNames, e );

--- a/Runtime/Antlr3.Runtime/RecognizerSharedState.cs
+++ b/Runtime/Antlr3.Runtime/RecognizerSharedState.cs
@@ -96,7 +96,7 @@ namespace Antlr.Runtime
         public int backtracking;
 
         /** <summary>
-         *  An array[size num rules] of Map<Integer,Integer> that tracks
+         *  An array[size num rules] of dictionaries that tracks
          *  the stop token index for each rule.  ruleMemo[ruleIndex] is
          *  the memoization table for ruleIndex.  For key ruleStartIndex, you
          *  get back the stop token for associated rule or MEMO_RULE_FAILED.

--- a/Runtime/Antlr3.Runtime/Tree/ITreeAdaptor.cs
+++ b/Runtime/Antlr3.Runtime/Tree/ITreeAdaptor.cs
@@ -139,7 +139,7 @@ namespace Antlr.Runtime.Tree
          *  the last symbol consumed during recovery.
          *  </summary>
          *
-         *  </remarks>
+         *  <remarks>
          *  You must specify the input stream so that the erroneous text can
          *  be packaged up in the error node.  The exception could be useful
          *  to some applications; default implementation stores ptr to it in

--- a/Runtime/Antlr3.Runtime/Tree/ITreeNodeStream.cs
+++ b/Runtime/Antlr3.Runtime/Tree/ITreeNodeStream.cs
@@ -47,17 +47,17 @@ namespace Antlr.Runtime.Tree
         }
 
         /** <summary>
-         * Get tree node at current input pointer + {@code k} ahead where
-         * {@code k==1} is next node. {@code k<0} indicates nodes in the past. So
+         * Get tree node at current input pointer + <paramref name="k"/> ahead where
+         * <paramref name="k"/>==1 is next node. <paramref name="k"/>&lt;0 indicates nodes in the past. So
          * {@code LT(-1)} is previous node, but implementations are not required to
-         * provide results for {@code k < -1}. {@code LT(0)} is undefined. For
-         * {@code k<=n}, return {@code null}. Return {@code null} for {@code LT(0)}
+         * provide results for <paramref name="k"/> &lt; -1. {@code LT(0)} is undefined. For
+         * <paramref name="k"/>&lt;=n, return <see langword="null"/>. Return <see langword="null"/> for {@code LT(0)}
          * and any index that results in an absolute address that is negative.
          *  </summary>
          *
          *  <remarks>
-         * This is analogous to {@link TokenStream#LT}, but this returns a tree node
-         * instead of a {@link Token}. Makes code generation identical for both
+         * This is analogous to <see cref="ITokenStream.LT(int)"/>, but this returns a tree node
+         * instead of a <see cref="IToken"/>. Makes code generation identical for both
          * parser and tree grammars.
          *  </remarks>
          */

--- a/Runtime/Antlr3.Runtime/Tree/RewriteRuleElementStream.cs
+++ b/Runtime/Antlr3.Runtime/Tree/RewriteRuleElementStream.cs
@@ -62,10 +62,10 @@ namespace Antlr.Runtime.Tree
          */
         protected int cursor = 0;
 
-        /** <summary>Track single elements w/o creating a list.  Upon 2nd add, alloc list */
+        /** <summary>Track single elements w/o creating a list.  Upon 2nd add, alloc list</summary> */
         protected object singleElement;
 
-        /** <summary>The list of tokens or subtrees we are tracking */
+        /** <summary>The list of tokens or subtrees we are tracking</summary> */
         protected IList elements;
 
         /** <summary>Once a node / subtree has been used in a stream, it must be dup'd
@@ -77,7 +77,7 @@ namespace Antlr.Runtime.Tree
 
         /** <summary>The element or stream description; usually has name of the token or
          *  rule reference that this list tracks.  Can include rulename too, but
-         *  the exception would track that info.
+         *  the exception would track that info.</summary>
          */
         protected string elementDescription;
         protected ITreeAdaptor adaptor;


### PR DESCRIPTION
This change cleans up the build output. It was originally part of #53, but is submitted as a separate review to narrow the scope.

* Disable CS1573 and CS1591
* Fix all CS1570, CS1574, and CS1587
