### PR TITLE
Mark GetObjectData with SecurityCriticalAttribute

### DIFF
--- a/Runtime/Antlr3.Runtime/EarlyExitException.cs
+++ b/Runtime/Antlr3.Runtime/EarlyExitException.cs
@@ -36,6 +36,7 @@ namespace Antlr.Runtime
     using Exception = System.Exception;
 
 #if !PORTABLE
+    using SecurityCriticalAttribute = System.Security.SecurityCriticalAttribute;
     using SerializationInfo = System.Runtime.Serialization.SerializationInfo;
     using StreamingContext = System.Runtime.Serialization.StreamingContext;
 #endif
@@ -98,6 +99,7 @@ namespace Antlr.Runtime
         }
 
 #if !PORTABLE
+        [SecurityCritical]
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
         {
             if (info == null)

--- a/Runtime/Antlr3.Runtime/FailedPredicateException.cs
+++ b/Runtime/Antlr3.Runtime/FailedPredicateException.cs
@@ -36,6 +36,7 @@ namespace Antlr.Runtime
     using Exception = System.Exception;
 
 #if !PORTABLE
+    using SecurityCriticalAttribute = System.Security.SecurityCriticalAttribute;
     using SerializationInfo = System.Runtime.Serialization.SerializationInfo;
     using StreamingContext = System.Runtime.Serialization.StreamingContext;
 #endif
@@ -117,6 +118,7 @@ namespace Antlr.Runtime
         }
 
 #if !PORTABLE
+        [SecurityCritical]
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
         {
             if (info == null)

--- a/Runtime/Antlr3.Runtime/MismatchedRangeException.cs
+++ b/Runtime/Antlr3.Runtime/MismatchedRangeException.cs
@@ -36,6 +36,7 @@ namespace Antlr.Runtime
     using Exception = System.Exception;
 
 #if !PORTABLE
+    using SecurityCriticalAttribute = System.Security.SecurityCriticalAttribute;
     using SerializationInfo = System.Runtime.Serialization.SerializationInfo;
     using StreamingContext = System.Runtime.Serialization.StreamingContext;
 #endif
@@ -110,6 +111,7 @@ namespace Antlr.Runtime
         }
 
 #if !PORTABLE
+        [SecurityCritical]
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
         {
             if (info == null)

--- a/Runtime/Antlr3.Runtime/MismatchedSetException.cs
+++ b/Runtime/Antlr3.Runtime/MismatchedSetException.cs
@@ -36,6 +36,7 @@ namespace Antlr.Runtime
     using Exception = System.Exception;
 
 #if !PORTABLE
+    using SecurityCriticalAttribute = System.Security.SecurityCriticalAttribute;
     using SerializationInfo = System.Runtime.Serialization.SerializationInfo;
     using StreamingContext = System.Runtime.Serialization.StreamingContext;
 #endif
@@ -97,6 +98,7 @@ namespace Antlr.Runtime
         }
 
 #if !PORTABLE
+        [SecurityCritical]
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
         {
             if (info == null)

--- a/Runtime/Antlr3.Runtime/MismatchedTokenException.cs
+++ b/Runtime/Antlr3.Runtime/MismatchedTokenException.cs
@@ -38,6 +38,7 @@ namespace Antlr.Runtime
     using Exception = System.Exception;
 
 #if !PORTABLE
+    using SecurityCriticalAttribute = System.Security.SecurityCriticalAttribute;
     using SerializationInfo = System.Runtime.Serialization.SerializationInfo;
     using StreamingContext = System.Runtime.Serialization.StreamingContext;
 #endif
@@ -124,6 +125,7 @@ namespace Antlr.Runtime
         }
 
 #if !PORTABLE
+        [SecurityCritical]
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
         {
             if (info == null)

--- a/Runtime/Antlr3.Runtime/MismatchedTreeNodeException.cs
+++ b/Runtime/Antlr3.Runtime/MismatchedTreeNodeException.cs
@@ -37,6 +37,7 @@ namespace Antlr.Runtime
     using ITreeNodeStream = Antlr.Runtime.Tree.ITreeNodeStream;
 
 #if !PORTABLE
+    using SecurityCriticalAttribute = System.Security.SecurityCriticalAttribute;
     using SerializationInfo = System.Runtime.Serialization.SerializationInfo;
     using StreamingContext = System.Runtime.Serialization.StreamingContext;
 #endif
@@ -98,6 +99,7 @@ namespace Antlr.Runtime
         }
 
 #if !PORTABLE
+        [SecurityCritical]
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
         {
             if (info == null)

--- a/Runtime/Antlr3.Runtime/NoViableAltException.cs
+++ b/Runtime/Antlr3.Runtime/NoViableAltException.cs
@@ -36,6 +36,7 @@ namespace Antlr.Runtime
     using Exception = System.Exception;
 
 #if !PORTABLE
+    using SecurityCriticalAttribute = System.Security.SecurityCriticalAttribute;
     using SerializationInfo = System.Runtime.Serialization.SerializationInfo;
     using StreamingContext = System.Runtime.Serialization.StreamingContext;
 #endif
@@ -145,6 +146,7 @@ namespace Antlr.Runtime
         }
 
 #if !PORTABLE
+        [SecurityCritical]
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
         {
             if (info == null)

--- a/Runtime/Antlr3.Runtime/RecognitionException.cs
+++ b/Runtime/Antlr3.Runtime/RecognitionException.cs
@@ -39,6 +39,7 @@ namespace Antlr.Runtime
     using NotSupportedException = System.NotSupportedException;
 
 #if !PORTABLE
+    using SecurityCriticalAttribute = System.Security.SecurityCriticalAttribute;
     using SerializationInfo = System.Runtime.Serialization.SerializationInfo;
     using StreamingContext = System.Runtime.Serialization.StreamingContext;
 #endif
@@ -359,6 +360,7 @@ namespace Antlr.Runtime
         }
 
 #if !PORTABLE
+        [SecurityCritical]
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
         {
             if (info == null)

--- a/Runtime/Antlr3.Runtime/Tree/RewriteCardinalityException.cs
+++ b/Runtime/Antlr3.Runtime/Tree/RewriteCardinalityException.cs
@@ -36,6 +36,7 @@ namespace Antlr.Runtime.Tree
     using Exception = System.Exception;
 
 #if !PORTABLE
+    using SecurityCriticalAttribute = System.Security.SecurityCriticalAttribute;
     using SerializationInfo = System.Runtime.Serialization.SerializationInfo;
     using StreamingContext = System.Runtime.Serialization.StreamingContext;
 #endif
@@ -88,6 +89,7 @@ namespace Antlr.Runtime.Tree
             _elementDescription = info.GetString("ElementDescription");
         }
 
+        [SecurityCritical]
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
         {
             if (info == null)


### PR DESCRIPTION
Fixes the following error:

```
TypeLoadException: Inheritance security rules violated while overriding member: '[member]'. Security accessibility of the overriding method must match the security accessibility of the method being overriden.
```