### PR TITLE
Relative paths for Template(Raw)GroupDirectory

### DIFF
--- a/Antlr4.StringTemplate/TemplateGroupDirectory.cs
+++ b/Antlr4.StringTemplate/TemplateGroupDirectory.cs
@@ -76,7 +76,7 @@ namespace Antlr4.StringTemplate
                 if (Directory.Exists(dirName))
                 {
                     // we found the directory and it'll be file based
-                    root = new Uri(dirName);
+                    root = new Uri(Path.GetFullPath(dirName));
                 }
                 else
                 {


### PR DESCRIPTION
`new TemplateRawDictionary("dir")` does not work and `new Uri()` throws exception, although `Path.GetFullPath()` returns true.

With this change, both relative and absolute directory paths can be used. Btw, `TemplateGroupFile` already uses `GetFullPath()`. This fixes #73