### PR TITLE
Set the default XML namespace for imported build props/targets

### DIFF
--- a/AntlrBuildTask/Antlr3.CodeGenerator.DefaultItems.props
+++ b/AntlrBuildTask/Antlr3.CodeGenerator.DefaultItems.props
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <!--
     Note: In this file, only items may be conditioned on the Antlr4IsSdkProject property. The EnableDefaultAntlrItems

--- a/AntlrBuildTask/Antlr3.CodeGenerator.DefaultItems.targets
+++ b/AntlrBuildTask/Antlr3.CodeGenerator.DefaultItems.targets
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
     <EnableDefaultAntlrItems Condition="'$(EnableDefaultAntlrItems)' == ''">True</EnableDefaultAntlrItems>


### PR DESCRIPTION
Fixes the following error prior to Visual Studio 2017:

> C:\\projects\\antlr-integration-tests-csharp\\antlr3\\CsprojConsoleApplication\\packages\\Antlr3.CodeGenerator.3.5.2-dev\\build\\Antlr3.CodeGenerator.DefaultItems.props(2,1): error MSB4041: The default XML namespace of the project must be the MSBuild XML namespace