### PR TITLE
Remove the lamdba allocation during TypeRegistry`1.TryGetValue (which…

### DIFF
--- a/Antlr4.StringTemplate/Misc/TypeRegistry`1.cs
+++ b/Antlr4.StringTemplate/Misc/TypeRegistry`1.cs
@@ -238,7 +238,15 @@ namespace Antlr4.StringTemplate.Misc
                 }
             }
 
-            List<Type> candidates = _backingStore.Keys.Where(i => i.IsAssignableFrom(key)).ToList();
+            List<Type> candidates = new List<Type>();
+            foreach (var i in this._backingStore.Keys)
+            {
+                if (i.IsAssignableFrom(key))
+                {
+                    candidates.Add(i);
+                }
+            }
+
             if (candidates.Count == 0)
             {
                 _cache[key] = null;


### PR DESCRIPTION
… is called indirectly by Template.Render())

`.Where(i => i.IsAssignableFrom(key))` is using `key` which is captured from the surrounding closure. Therefore, the runtime allocates a new object to capture the `Func<Type, bool>` paired with it's required `key` input (rather than if there were, say, a `WhereWithState<TSource, TState, TResult>(TSource, TState)` method).

Since this is called by `Template.Render()` it adds unnecessary overhead we can remove without changes to the runtime by expanding the LINQ statement into a foreach loop.