### PR TITLE
Remove BuildingInsideVisualStudio condition on CoreCompileDependsOn

### DIFF
--- a/AntlrBuildTask/Antlr3.CodeGenerator.targets
+++ b/AntlrBuildTask/Antlr3.CodeGenerator.targets
@@ -111,7 +111,7 @@
   <PropertyGroup>
     <!-- Add grammar compilation to the CoreCompileDependsOn so that the IDE inproc compilers (particularly VB)
          can "see" the generated source files. -->
-    <CoreCompileDependsOn Condition="'$(BuildingInsideVisualStudio)' == 'true' ">
+    <CoreCompileDependsOn>
       DesignTimeGrammarCompilation;
       $(CoreCompileDependsOn)
     </CoreCompileDependsOn>

--- a/AntlrBuildTask/Antlr3.Java.targets
+++ b/AntlrBuildTask/Antlr3.Java.targets
@@ -85,7 +85,7 @@
   <PropertyGroup>
     <!-- Add grammar compilation to the CoreCompileDependsOn so that the IDE inproc compilers (particularly VB)
          can "see" the generated source files. -->
-    <CoreCompileDependsOn Condition="'$(BuildingInsideVisualStudio)' == 'true' ">
+    <CoreCompileDependsOn>
       DesignTimeGrammarCompilation;
       $(CoreCompileDependsOn)
     </CoreCompileDependsOn>


### PR DESCRIPTION
This condition prevents Rider to "see" the generated files in design time. The `DesignTimeGrammarCompilation` has already condition on `DesignTimeBuild` which should be sufficient.